### PR TITLE
update to new brew syntax for cask installs

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -11,7 +11,7 @@ Just a little Mac screensaver inspired by the [Braun watches](http://braun-clock
 
 Alternatively, if you're using [Homebrew](https://brew.sh), you can run:
 ```
-$ brew cask install clocksaver
+$ brew install --cask clocksaver
 ```
 
 


### PR DESCRIPTION
running `brew cask install...` will result in a deprecation error and point you to the `--cask` flag in the cli. Simple update to the readme